### PR TITLE
Delete extconf.rb

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -1,6 +1,0 @@
-require 'mkmf'
-# .. more stuff
-#$LIBPATH.push(Config::CONFIG['libdir'])
-$CFLAGS << " #{ENV["CFLAGS"]}"
-$LIBS << " #{ENV["LIBS"]}"
-create_makefile("libsass")


### PR DESCRIPTION
This file is unused, the Ruby gem is at sass/sassc-ruby